### PR TITLE
Make ForceTouchController more self-aware, preparations for better widget, bugfixes

### DIFF
--- a/GoodNight/AppDelegate.m
+++ b/GoodNight/AppDelegate.m
@@ -53,6 +53,10 @@
     [self registerForNotifications];
     [AppDelegate updateNotifications];
     
+    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"9.0") && [[[self window] traitCollection] forceTouchCapability] == UIForceTouchCapabilityAvailable){
+        [ForceTouchController sharedForceTouchController];
+    }
+    
     if (application.applicationState == UIApplicationStateBackground) {
         [self installBackgroundTask:application];
     }

--- a/GoodNight/ForceTouchController.h
+++ b/GoodNight/ForceTouchController.h
@@ -13,6 +13,7 @@ static BOOL forceTouchActionEnabled = NO;
 
 @interface ForceTouchController : NSObject
 
++ (id)sharedForceTouchController;
 + (UIApplicationShortcutItem *)shortcutItemForCurrentState;
 + (void)updateShortcutItems;
 + (BOOL)handleShortcutItem:(UIApplicationShortcutItem *)shortcutItem;

--- a/GoodNight/ForceTouchController.m
+++ b/GoodNight/ForceTouchController.m
@@ -40,7 +40,6 @@
 
 -(void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
 {
-    NSLog(@"KVO: %@ changed property %@ to value %@", object, keyPath, change);
     [ForceTouchController updateShortcutItems];
 }
 

--- a/GoodNight/ForceTouchController.m
+++ b/GoodNight/ForceTouchController.m
@@ -11,6 +11,39 @@
 
 @implementation ForceTouchController
 
++ (id)sharedForceTouchController
+{
+    //Singleton
+    static dispatch_once_t once;
+    static ForceTouchController *sharedForceTouchController = nil;
+    
+    dispatch_once(&once, ^{
+        sharedForceTouchController = [[self alloc] init];
+        
+        //[[NSNotificationCenter defaultCenter] addObserver:sharedForceTouchController selector:@selector(userDefaultsChanged:) name:NSUserDefaultsDidChangeNotification object:nil];
+        [userDefaults addObserver:sharedForceTouchController forKeyPath:@"enabled" options:NSKeyValueObservingOptionNew context:NULL];
+        [userDefaults addObserver:sharedForceTouchController forKeyPath:@"dimEnabled" options:NSKeyValueObservingOptionNew context:NULL];
+        [userDefaults addObserver:sharedForceTouchController forKeyPath:@"rgbEnabled" options:NSKeyValueObservingOptionNew context:NULL];
+        [userDefaults addObserver:sharedForceTouchController forKeyPath:@"keyEnabled" options:NSKeyValueObservingOptionNew context:NULL];
+    });
+    
+    return sharedForceTouchController;
+}
+
+- (void) dealloc
+{
+    [userDefaults removeObserver:self forKeyPath:@"enabled"];
+    [userDefaults removeObserver:self forKeyPath:@"dimEnabled"];
+    [userDefaults removeObserver:self forKeyPath:@"rgbEnabled"];
+    [userDefaults removeObserver:self forKeyPath:@"keyEnabled"];
+}
+
+-(void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
+{
+    NSLog(@"KVO: %@ changed property %@ to value %@", object, keyPath, change);
+    [ForceTouchController updateShortcutItems];
+}
+
 + (UIApplicationShortcutItem *)shortcutItemForCurrentState {
     NSString *shortcutType, *shortcutTitle, *shortcutSubtitle, *iconTemplate = nil;
     

--- a/GoodNight/GammaController.m
+++ b/GoodNight/GammaController.m
@@ -7,7 +7,6 @@
 //
 
 #import "GammaController.h"
-#import "ForceTouchController.h"
 
 #import "NSDate+Extensions.h"
 #include <dlfcn.h>
@@ -182,7 +181,6 @@
     }
     [userDefaults setFloat:orangeLevel forKey:@"currentOrange"];
     [userDefaults synchronize];
-    [ForceTouchController updateShortcutItems];
 }
 
 static NSOperationQueue *queue = nil;
@@ -249,7 +247,6 @@ static NSOperationQueue *queue = nil;
     }
     [userDefaults setFloat:1.0 forKey:@"currentOrange"];
     [userDefaults synchronize];
-    [ForceTouchController updateShortcutItems];
 }
 
 + (BOOL)wakeUpScreenIfNeeded {
@@ -293,7 +290,6 @@ static NSOperationQueue *queue = nil;
         [self showFailedAlertWithKey:@"dimEnabled"];
     }
     [userDefaults synchronize];
-    [ForceTouchController updateShortcutItems];
 }
 
 + (void)setGammaWithCustomValues {
@@ -309,7 +305,6 @@ static NSOperationQueue *queue = nil;
         [self showFailedAlertWithKey:@"rgbEnabled"];
     }
     [userDefaults synchronize];
-    [ForceTouchController updateShortcutItems];
 }
 
 + (void)disableColorAdjustment {

--- a/GoodNight/GammaController.m
+++ b/GoodNight/GammaController.m
@@ -228,11 +228,7 @@ static NSOperationQueue *queue = nil;
 }
 
 + (void)disableOrangenessWithDefaults:(BOOL)defaults key:(NSString *)key transition:(BOOL)transition {
-    float currentOrangeLevel = [userDefaults floatForKey:@"currentOrange"];
-    if (currentOrangeLevel == 1.0) {
-        return;
-    }
-    
+
     [self wakeUpScreenIfNeeded];
     if (transition == YES) {
         float currentOrangeLevel = [userDefaults floatForKey:@"currentOrange"];
@@ -316,6 +312,10 @@ static NSOperationQueue *queue = nil;
 }
 
 + (void)disableOrangeness {
+    float currentOrangeLevel = [userDefaults floatForKey:@"currentOrange"];
+    if (!(currentOrangeLevel < 1.0f)) {
+        return;
+    }
     [GammaController disableOrangenessWithDefaults:YES key:@"enabled" transition:YES];
 }
 


### PR DESCRIPTION
- Make ForceTouchController more self-aware and remove references of ForceTouchController from GammaController (MVC).
- These are preparations for an enhanced widget that doesn't need to open the app for executing changes (no more URLschemes).
- Also fixes some bugs.