### PR TITLE
This fixes #26 '6500K Temperature is not displaying correctly'

### DIFF
--- a/GoodNight/GammaController.m
+++ b/GoodNight/GammaController.m
@@ -199,6 +199,9 @@ static NSOperationQueue *queue = nil;
         if (newPercentOrange > oldPercentOrange) {
             for (float i = oldPercentOrange; i <= newPercentOrange; i = i + 0.01) {
                 if (weakOperation.isCancelled) break;
+                if (i > 0.99) {
+                    i = 1.0f;
+                }
                 [NSThread sleepForTimeInterval:0.02];
                 [self setGammaWithOrangeness:i];
             }
@@ -207,7 +210,7 @@ static NSOperationQueue *queue = nil;
             for (float i = oldPercentOrange; i >= newPercentOrange; i = i - 0.01) {
                 if (weakOperation.isCancelled) break;
                 if (i < 0.01) {
-                    i = 0;
+                    i = 0.0f;
                 }
                 [NSThread sleepForTimeInterval:0.02];
                 [self setGammaWithOrangeness:i];


### PR DESCRIPTION
Changes in 94c834f9e9b9307e3236d3d6113391c9d40baac0 (introducing Kelvin scale) did change the usage of the value of the slider. 
This fixes #26 '6500K Temperature is not displaying correctly', which resulted from former commit.