### PR TITLE
Fixes several bugs in last commits.

### DIFF
--- a/GoodNight.xcodeproj/project.pbxproj
+++ b/GoodNight.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		32AFEC481C1B1B8A00142DD9 /* IOMobileFramebufferClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 32AFEC471C1B1B8A00142DD9 /* IOMobileFramebufferClient.m */; };
+		755923FF1C214F7C000E62AE /* MobileGestaltClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 755923FE1C214F7C000E62AE /* MobileGestaltClient.m */; };
 		921810341BC1B1C300D32E92 /* CreditsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 921810331BC1B1C300D32E92 /* CreditsViewController.m */; };
 		921810371BC1B3C000D32E92 /* BrightnessViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 921810361BC1B3C000D32E92 /* BrightnessViewController.m */; };
 		921DE7511C20D591005C3F92 /* Defaults.plist in Resources */ = {isa = PBXBuildFile; fileRef = 921DE7501C20D591005C3F92 /* Defaults.plist */; };
@@ -62,6 +63,8 @@
 		511EBE611BEBB1E200D5DAF7 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		511EBE621BEBB1E200D5DAF7 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Storyboard.strings; sourceTree = "<group>"; };
 		511EBE631BEBB1E200D5DAF7 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/MainInterface.strings; sourceTree = "<group>"; };
+		755923FD1C214F7C000E62AE /* MobileGestaltClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MobileGestaltClient.h; sourceTree = "<group>"; };
+		755923FE1C214F7C000E62AE /* MobileGestaltClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MobileGestaltClient.m; sourceTree = "<group>"; };
 		921810321BC1B1C300D32E92 /* CreditsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CreditsViewController.h; sourceTree = "<group>"; };
 		921810331BC1B1C300D32E92 /* CreditsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CreditsViewController.m; sourceTree = "<group>"; };
 		921810351BC1B3C000D32E92 /* BrightnessViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BrightnessViewController.h; sourceTree = "<group>"; };
@@ -125,6 +128,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		755923FC1C214F6B000E62AE /* libMobileGestalt */ = {
+			isa = PBXGroup;
+			children = (
+				755923FD1C214F7C000E62AE /* MobileGestaltClient.h */,
+				755923FE1C214F7C000E62AE /* MobileGestaltClient.m */,
+			);
+			name = libMobileGestalt;
+			sourceTree = "<group>";
+		};
 		921924341BCDC11800254487 /* NSDate+Extensions */ = {
 			isa = PBXGroup;
 			children = (
@@ -272,6 +284,7 @@
 		92BC7DF41C1F859600574361 /* Clients */ = {
 			isa = PBXGroup;
 			children = (
+				755923FC1C214F6B000E62AE /* libMobileGestalt */,
 				92BC7DF71C1F876700574361 /* IOMobileFramebuffer */,
 				92BC7DF61C1F85D500574361 /* SpringBoardServices */,
 			);
@@ -395,7 +408,7 @@
 				TargetAttributes = {
 					925B811D1BE2BCE1003A6C4B = {
 						CreatedOnToolsVersion = 7.2;
-						DevelopmentTeam = 9QKLXG4845;
+						DevelopmentTeam = RZ4ZD385GT;
 						SystemCapabilities = {
 							com.apple.Keychain = {
 								enabled = 0;
@@ -404,7 +417,7 @@
 					};
 					B9E536451B38D90D0097BF90 = {
 						CreatedOnToolsVersion = 7.0;
-						DevelopmentTeam = 9QKLXG4845;
+						DevelopmentTeam = RZ4ZD385GT;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
 								enabled = 1;
@@ -481,6 +494,7 @@
 				926F71261C0CF39B0039A4A2 /* Brightness.c in Sources */,
 				B9E5364E1B38D90D0097BF90 /* AppDelegate.m in Sources */,
 				929602A21BD1BC3000CDEC52 /* SettingsViewController.m in Sources */,
+				755923FF1C214F7C000E62AE /* MobileGestaltClient.m in Sources */,
 				B9E5364B1B38D90D0097BF90 /* main.m in Sources */,
 				B96BB64F1B38D96600F1C3AE /* GammaController.m in Sources */,
 				926F71271C0CF39B0039A4A2 /* Solar.c in Sources */,

--- a/GoodNight/GammaController.m
+++ b/GoodNight/GammaController.m
@@ -16,6 +16,7 @@
 #import "Brightness.h"
 #import "IOMobileFramebufferClient.h"
 #import "SpringBoardServicesClient.h"
+#import "MobileGestaltClient.h"
 
 @implementation GammaController
 
@@ -43,7 +44,7 @@
 }
 
 + (void)setGammaWithRed:(float)red green:(float)green blue:(float)blue {
-    if (![[IOMobileFramebufferClient sharedInstance] gammaTableFunctionIsUsable]) {
+    if (![self gammaTableFunctionIsUsable]) {
         [self setGammaWithMatrixAndRed:red green:green blue:blue];
     }
     else {
@@ -409,6 +410,15 @@
     va_end(args);
 
     return adjustmentsEnabled;
+}
+
++ (BOOL)gammaTableFunctionIsUsable {
+    NSString *hwModelStr = [[MobileGestaltClient sharedInstance] MGGetHWModelStr];
+    
+    if ([hwModelStr isEqualToString:@"J98aAP"] || [hwModelStr isEqualToString:@"J99aAP"]) {
+        return NO;
+    }
+    return YES;
 }
 
 @end

--- a/GoodNight/GammaController.m
+++ b/GoodNight/GammaController.m
@@ -43,10 +43,10 @@
 }
 
 + (void)setGammaWithRed:(float)red green:(float)green blue:(float)blue {
-    if ([[IOMobileFramebufferClient sharedInstance] gamutMatrixFunctionIsAvailable]) {
+    if (![[IOMobileFramebufferClient sharedInstance] gammaTableFunctionIsUsable]) {
         [self setGammaWithMatrixAndRed:red green:green blue:blue];
     }
-    else if (![[IOMobileFramebufferClient sharedInstance] gamutMatrixFunctionIsAvailable]) {
+    else {
         [self setGammaWithTableAndRed:red green:green blue:blue];
     }
 }

--- a/GoodNight/IOMobileFramebufferClient.h
+++ b/GoodNight/IOMobileFramebufferClient.h
@@ -50,6 +50,6 @@ typedef struct {
 - (void)gammaTable:(IOMobileFramebufferGammaTable *)table;
 - (void)setGammaTable:(IOMobileFramebufferGammaTable *)table;
 
-- (BOOL)gamutMatrixFunctionIsAvailable;
+- (BOOL)gammaTableFunctionIsUsable;
 
 @end

--- a/GoodNight/IOMobileFramebufferClient.h
+++ b/GoodNight/IOMobileFramebufferClient.h
@@ -50,6 +50,4 @@ typedef struct {
 - (void)gammaTable:(IOMobileFramebufferGammaTable *)table;
 - (void)setGammaTable:(IOMobileFramebufferGammaTable *)table;
 
-- (BOOL)gammaTableFunctionIsUsable;
-
 @end

--- a/GoodNight/IOMobileFramebufferClient.m
+++ b/GoodNight/IOMobileFramebufferClient.m
@@ -118,14 +118,11 @@ s1516 GamutMatrixValue(double value) {
     [self callFramebufferFunction:@"IOMobileFramebufferGetGammaTable" withFirstParamPointer:table];
 }
 
-- (BOOL)gamutMatrixFunctionIsAvailable {
+- (BOOL)gammaTableFunctionIsUsable {
     if (iPadProIsCurrentDevice) {
-        return YES;
+        return NO;
     }
-    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"8.3")) {
-        return YES;
-    }
-    return NO;
+    return YES;
 }
 
 @end

--- a/GoodNight/IOMobileFramebufferClient.m
+++ b/GoodNight/IOMobileFramebufferClient.m
@@ -72,13 +72,15 @@ s1516 GamutMatrixValue(double value) {
 }
 
 - (IOMobileFramebufferColorRemapMode)colorRemapMode {
-    IOMobileFramebufferReturn (*IOMobileFramebufferGetColorRemapMode)(IOMobileFramebufferConnection connection, IOMobileFramebufferColorRemapMode *mode) = dlsym(IOMobileFramebufferHandle, "IOMobileFramebufferGetColorRemapMode");
-    NSParameterAssert(IOMobileFramebufferGetColorRemapMode);
-    IOMobileFramebufferColorRemapMode mode = IOMobileFramebufferColorRemapModeNormal;
-    IOMobileFramebufferReturn returnValue = IOMobileFramebufferGetColorRemapMode(self.framebufferConnection, &mode);
+    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"9.0")) {
+        IOMobileFramebufferReturn (*IOMobileFramebufferGetColorRemapMode)(IOMobileFramebufferConnection connection, IOMobileFramebufferColorRemapMode *mode) = dlsym(IOMobileFramebufferHandle, "IOMobileFramebufferGetColorRemapMode");
+        NSParameterAssert(IOMobileFramebufferGetColorRemapMode);
+        IOMobileFramebufferColorRemapMode mode = IOMobileFramebufferColorRemapModeNormal;
+        IOMobileFramebufferReturn returnValue = IOMobileFramebufferGetColorRemapMode(self.framebufferConnection, &mode);
 
-    if (returnValue == 0) {
-        return mode;
+        if (returnValue == 0) {
+            return mode;
+        }
     }
 
     return IOMobileFramebufferColorRemapModeError;

--- a/GoodNight/IOMobileFramebufferClient.m
+++ b/GoodNight/IOMobileFramebufferClient.m
@@ -120,11 +120,4 @@ s1516 GamutMatrixValue(double value) {
     [self callFramebufferFunction:@"IOMobileFramebufferGetGammaTable" withFirstParamPointer:table];
 }
 
-- (BOOL)gammaTableFunctionIsUsable {
-    if (iPadProIsCurrentDevice) {
-        return NO;
-    }
-    return YES;
-}
-
 @end

--- a/GoodNight/MobileGestaltClient.h
+++ b/GoodNight/MobileGestaltClient.h
@@ -1,0 +1,17 @@
+//
+//  MobileGestaltClient.h
+//  GoodNight
+//
+//  Created by Mario Korte on 11.12.2015.
+//  Copyright © 2015 ADA Tech, LLC. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface MobileGestaltClient : NSObject
+
++ (instancetype)sharedInstance;
+
+- (NSString*)MGGetHWModelStr;
+
+@end

--- a/GoodNight/MobileGestaltClient.m
+++ b/GoodNight/MobileGestaltClient.m
@@ -1,0 +1,55 @@
+//
+//  MobileGestaltClient.m
+//  GoodNight
+//
+//  Created by Mario Korte on 11.12.2015.
+//  Copyright © 2015 ADA Tech, LLC. All rights reserved.
+//
+
+#import <dlfcn.h>
+#import "MobileGestaltClient.h"
+
+#define LMG_PATH "/usr/lib/libMobileGestalt.dylib"
+
+@implementation MobileGestaltClient
+
+static void *MobileGestaltClientHandle = NULL;
+static NSString *HWModelString;
+
++ (void)initialize {
+    [super initialize];
+
+    MobileGestaltClientHandle = dlopen(LMG_PATH, RTLD_GLOBAL | RTLD_LAZY);
+    NSParameterAssert(MobileGestaltClientHandle);
+}
+
++ (instancetype)sharedInstance {
+    static dispatch_once_t onceToken = 0;
+    static MobileGestaltClient *sharedMobileGestaltClient = nil;
+    
+    dispatch_once(&onceToken, ^{
+        sharedMobileGestaltClient = [[self alloc] init];
+    });
+    
+    return sharedMobileGestaltClient;
+}
+
+- (void)dealloc {
+    dlclose(MobileGestaltClientHandle);
+}
+
+- (NSString*)callMGCopyAnswer:(NSString*)input{
+    CFStringRef (*MGCopyAnswer)(CFStringRef model) = dlsym(MobileGestaltClientHandle, "MGCopyAnswer");
+    NSParameterAssert(MGCopyAnswer);
+    NSString *answer = CFBridgingRelease(MGCopyAnswer((__bridge CFStringRef)input));
+    return answer;
+}
+
+- (NSString*)MGGetHWModelStr{
+    if (!HWModelString){
+        HWModelString = [self callMGCopyAnswer:@"HWModelStr"];
+    }
+    return HWModelString;
+}
+
+@end

--- a/GoodNight/MobileGestaltClient.m
+++ b/GoodNight/MobileGestaltClient.m
@@ -14,7 +14,7 @@
 @implementation MobileGestaltClient
 
 static void *MobileGestaltClientHandle = NULL;
-static NSString *HWModelString;
+static NSString *HWModelString = nil;
 
 + (void)initialize {
     [super initialize];


### PR DESCRIPTION
- Fixes #51 'Latest Build not Working Right': If possible we should ALWAYS prefer the real GammaTable function, as its intent is exactly what this app is trying to achieve. Edit the GammaTable of the FB. Only use GamusMatrix as a fallback if no other choice is available.
- The check for iPad Pro was faulty. Only way to really know the HW model is MobileGestalt
- Fixes crash on iOS<9.0 due to IOMobileFramebufferGetColorRemapMode