### PR TITLE
Added methods to disable "Reduce White Point" before adjusting screen temp

### DIFF
--- a/GoodNight/GammaController.m
+++ b/GoodNight/GammaController.m
@@ -203,6 +203,9 @@
     }
     
     [self wakeUpScreenIfNeeded];
+    
+    [[IOMobileFramebufferClient sharedInstance] resetBrightnessCorrection];
+    
     if (transition == YES) {
         [self setGammaWithTransitionFrom:currentOrangeLevel to:orangeLevel];
     }
@@ -287,6 +290,8 @@
 }
 
 + (void)enableDimness {
+    [[IOMobileFramebufferClient sharedInstance] resetBrightnessCorrection];
+    
     float dimLevel = [userDefaults floatForKey:@"dimLevel"];
     [self setGammaWithRed:dimLevel green:dimLevel blue:dimLevel];
     [userDefaults setBool:YES forKey:@"dimEnabled"];
@@ -295,6 +300,8 @@
 }
 
 + (void)setGammaWithCustomValues {
+    [[IOMobileFramebufferClient sharedInstance] resetBrightnessCorrection];
+    
     float redValue = [userDefaults floatForKey:@"redValue"];
     float greenValue = [userDefaults floatForKey:@"greenValue"];
     float blueValue = [userDefaults floatForKey:@"blueValue"];

--- a/GoodNight/IOMobileFramebufferClient.h
+++ b/GoodNight/IOMobileFramebufferClient.h
@@ -36,6 +36,9 @@ typedef struct {
     } content;
 } IOMobileFramebufferGamutMatrix;
 
+static const uint32_t IOMobileFramebufferBrightnessCorrectionReducedWhitepointValue = 57344;
+static const uint32_t IOMobileFramebufferBrightnessCorrectionDefaultValue = 65535;
+
 @interface IOMobileFramebufferClient : NSObject
 
 @property (nonatomic, readonly) IOMobileFramebufferConnection framebufferConnection;
@@ -44,6 +47,9 @@ typedef struct {
 
 - (IOMobileFramebufferColorRemapMode)colorRemapMode;
 - (void)setColorRemapMode:(IOMobileFramebufferColorRemapMode)mode;
+
+- (void)setBrightnessCorrection:(uint32_t)correction;
+- (void)resetBrightnessCorrection;
 
 - (void)gamutMatrix:(IOMobileFramebufferGamutMatrix *)matrix;
 - (void)setGamutMatrix:(IOMobileFramebufferGamutMatrix *)matrix;

--- a/GoodNight/IOMobileFramebufferClient.m
+++ b/GoodNight/IOMobileFramebufferClient.m
@@ -90,6 +90,14 @@ s1516 GamutMatrixValue(double value) {
     [self callFramebufferFunction:@"IOMobileFramebufferSetColorRemapMode" withFirstParamScalar:mode];
 }
 
+- (void)setBrightnessCorrection:(uint32_t)correction {
+    [self callFramebufferFunction:@"IOMobileFramebufferSetBrightnessCorrection" withFirstParamScalar:correction];
+}
+
+- (void)resetBrightnessCorrection {
+    [self setBrightnessCorrection:IOMobileFramebufferBrightnessCorrectionDefaultValue];
+}
+
 - (void)setGamutMatrix:(IOMobileFramebufferGamutMatrix *)matrix {
     NSString *functionName = nil;
     if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"8.3") && SYSTEM_VERSION_LESS_THAN(@"9.0")) {


### PR DESCRIPTION
Previously this lead to weird screen color glitches.

Downsize: if "Reduce White Point" was activated before the user has to reactivate it again manually if he still wants it (or reboot the device)