### PR TITLE
Color temperature slider now snaps to 100K increments

### DIFF
--- a/GoodNight/MainViewController.m
+++ b/GoodNight/MainViewController.m
@@ -10,6 +10,24 @@
 #import "AppDelegate.h"
 #import "GammaController.h"
 
+
+// The multiple (in degrees Kelvin) to round orange values to
+#define ORANGE_VALUE_INCREMENT 100.0f
+
+// Given an currentOrangeValue as a float in the range [0.0, 1.0], converts it to Kelvin, rounds
+// to the nearest ORANGE_VALUE_INCREMENT, and returns the new orange value as a float.
+float roundOrangeValue(float currentOrangeValue) {
+    // Get the current slider value in Kelvin (rounded
+    float temperature = (currentOrangeValue * 4500.0f) + 2000.0f;
+
+    // Round to the nearest ORANGE_VALUE_INCREMENT degree Kelvin
+    float temperatureRounded = roundf(temperature / ORANGE_VALUE_INCREMENT) * ORANGE_VALUE_INCREMENT;
+
+    // Convert back to float value in range [0.0, 1.0] to get slider value
+    return ((temperatureRounded - 2000.0f) / 4500.0f);
+}
+
+
 @implementation MainViewController
 
 - (instancetype)init
@@ -271,6 +289,9 @@
 }
 
 - (IBAction)maxOrangeSliderChanged {
+    // Round the slider's value to a nice temperature increment
+    self.orangeSlider.value = roundOrangeValue(self.orangeSlider.value);
+
     NSString *key;
     switch (self.timeOfDaySegmentedControl.selectedSegmentIndex) {
         case 0:


### PR DESCRIPTION
This PR updates the behavior of the temperature slider so that, as the user drags it, it snaps to the nearest 100K increment temperature value. For example, if the user drags their finger to 4570K, the slider snaps to 4600K.

To do this, we add a new function to `MainViewController.m`, `roundOrangeValue()`. In the event handler for the orange slider value changing, we grab the current value, call `roundOrangeValue()` to round the value to the nearest 100K, and move the slider to this rounded value. 

The increment that we round to (100K, in this case) is controlled by the `#define ORANGE_VALUE_INCREMENT` statement at the top of `MainViewController.m`.

The benefit of this new behavior is that it makes it easier for the user to set the slider to a nice, round number. Most users probably want their temperature to be something like 3700K, rather than 3692K. With the old behavior, the slider was so sensitive that you could rarely get it exactly on a round number. Even if you could, lifting your finger off the screen would cause the slider to jump to some other ugly value.

This behavior matches how f.lux behaves (at least on Mac OS X).