### PR TITLE
Fix markdown/install links in readme and tidy up

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ the source.
 
 ### Installing
 
-See [here] (Help/README.md) for written instructions.  
-Click on [this link] (https://www.youtube.com/watch?v=Yu62IlaqPQM) to see the official install video.  
+See the [README](Help/README.md) for written instructions.  The
+[official install video](https://www.youtube.com/watch?v=Yu62IlaqPQM) is also available.  
 
 ### Compatibility
 
@@ -41,8 +41,10 @@ The **darkroom button** turns on darkroom mode and on deactivation of darkroom m
 The macOS version of GoodNight is out! You can currently enter RGB values between 0 and 255 for red, green, and blue values, enable a darkroom mode, and adjust the color temperature of the display. It also has Touch Bar support! More features will be coming soon. You can download the always up-to-date binary distribution release from [here][2].
 
 ### Installing
-It is crucial that you copy the application to the applications folder on your Mac. If you get an error while attempting to open the app, open up terminal, and type in this command:  
-`sudo spctl --master-disable`  
+It is crucial that you copy the application to the applications folder on your Mac. If you get an error while attempting to open the app, open up terminal, and type in this command:
+
+    sudo spctl --master-disable
+    
 Press return after you enter your password and try again. It should open successfully.
 
 [1]: https://github.com/thomasfinch/GammaThingy


### PR DESCRIPTION
A couple of minor formatting improvements; this makes the install links be links (extra space previously), and formats the install command as a code block.